### PR TITLE
Pin lightstep gem to 0.11.x

### DIFF
--- a/bc-lightstep-ruby.gemspec
+++ b/bc-lightstep-ruby.gemspec
@@ -35,6 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'pry'
 
-  spec.add_runtime_dependency 'lightstep', '~> 0.11'
+  spec.add_runtime_dependency 'lightstep', '~> 0.11.2'
   spec.add_runtime_dependency 'faraday', '~> 0.8'
 end


### PR DESCRIPTION
Lightstep gem has a backwards incompatible change in 0.12:

```
uninitialized constant LightStep::Tracer::FORMAT_TEXT_MAP
```

This pins us to 0.11.x until that is stable and fixed.

----

@bigcommerce/platform-engineering 