### PR TITLE
PEN-929: Add error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/bundle/
 *.gem
 .idea

--- a/lib/bigcommerce/lightstep/rails_controller_instrumentation.rb
+++ b/lib/bigcommerce/lightstep/rails_controller_instrumentation.rb
@@ -56,6 +56,7 @@ module Bigcommerce
         headers.each do |k, v|
           fk = k.to_s.downcase.gsub('http_', '').tr('_', '-')
           next unless OPEN_TRACING_HEADER_KEYS.include?(fk)
+
           filtered_ot_headers[fk] = v
         end
         filtered_ot_headers

--- a/lib/bigcommerce/lightstep/tracer.rb
+++ b/lib/bigcommerce/lightstep/tracer.rb
@@ -58,13 +58,18 @@ module Bigcommerce
         self.active_span = span
 
         # run the process
-        result = yield span
+        begin
+          result = yield span
+        rescue StandardError
+          span.set_tag('error', true)
+          raise
+        ensure
+          # finish this span if the reporter is initialized
+          span.finish if reporter_initialized?
 
-        # finish this span if the reporter is initialized
-        span.finish if reporter_initialized?
-
-        # now set back the parent as the active span
-        self.active_span = last_active_span
+          # now set back the parent as the active span
+          self.active_span = last_active_span
+        end
 
         # return result
         result

--- a/lib/bigcommerce/lightstep/transport.rb
+++ b/lib/bigcommerce/lightstep/transport.rb
@@ -47,8 +47,8 @@ module Bigcommerce
         verbose: 0,
         encryption: ENCRYPTION_TLS,
         ssl_verify_peer: true,
-        open_timeout: 20,
-        read_timeout: 20,
+        open_timeout: 2,
+        read_timeout: 2,
         continue_timeout: nil,
         keep_alive_timeout: 2,
         logger: nil
@@ -64,7 +64,9 @@ module Bigcommerce
         @keep_alive_timeout = keep_alive_timeout.to_i
 
         raise ::Bigcommerce::Lightstep::Errors::InvalidAccessToken, 'access_token must be a string' unless access_token.is_a?(String)
+
         raise ::Bigcommerce::Lightstep::Errors::InvalidAccessToken, 'access_token cannot be blank'  if access_token.empty?
+
         @access_token = access_token.to_s
         @logger = logger || ::Logger.new(STDOUT)
       end


### PR DESCRIPTION
* Make sure spans are finished and current span is reset if the measured
  block throws an error.
* Set tag `error = true` on exceptions in measured code
* Set more reasonable timeouts on Lightstep connections
* Fix a couple of linting errors.