### PR TITLE
Handle issue that occurs if lightstep is disabled but the start_span method is still called

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_from:
   - .rubocop_todo.yml
 
 AllCops:
+  TargetRubyVersion: 2.2
   Exclude:
     - spec/**/*
     - .bundle/**/*

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,6 +18,9 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 24
 
+Metrics/PerceivedComplexity:
+  Max: 10
+
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes.
 # URISchemes: http, https
 Metrics/LineLength:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ Changelog for the bc-lightstep-ruby gem.
 
 h3. Pending Release
 
+h3. 1.1.8
+
+- Handle issue that occurs if lightstep is disabled but the start_span method is still called
+- Remove FORMAT_TEXT_MAP reference as this is no longer present in later lightstep gem versions
+
 h3. 1.1.7
 
 - Better handling of exceptions and tagged errors


### PR DESCRIPTION
This fixes the case where the `Bigcommerce::Lightstep.configure` method is never called in a service, but `Bigcommerce::Lightstep.start_span` is, which triggers an issue in the underlying lightstep gem where it attempts to disable the reporter (which isn't set yet) and calls `flush` on `nil`.

----

@bigcommerce/platform-engineering 