### PR TITLE
PEN-975: Add configuration around reporting options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ Changelog for the bc-lightstep-ruby gem.
 
 h3. Pending Release
 
+- Bump lightstep gem to 0.13
+- Add LIGHTSTEP_MAX_BUFFERED_SPANS config ENV + setting for maximum number of spans to buffer
+- Add LIGHTSTEP_MAX_LOG_RECORDS config ENV + setting for maximum number of log records that can be on a span
+- Add LIGHTSTEP_MAX_REPORTING_INTERVAL_SECONDS config ENV + setting for max reporting flush interval to collector
+
 h3. 1.1.8
 
 - Handle issue that occurs if lightstep is disabled but the start_span method is still called

--- a/README.md
+++ b/README.md
@@ -40,13 +40,16 @@ bc-lightstep-ruby can be automatically configured from these ENV vars, if you'd 
 
 | Name | Description |
 | ---- | ----------- |
-| LIGHTSTEP_ENABLED | Flag to determine whether to broadcast spans. Defaults to 1 (enabled) and 0 will disable.|
-| LIGHTSTEP_COMPONENT_NAME | The component name to use |
-| LIGHTSTEP_ACCESS_TOKEN | The access token to use to connect to the collector |
-| LIGHTSTEP_HOST | Host of the collector. Defaults to `lightstep-collector.linkerd` |
-| LIGHTSTEP_PORT | Port of the collector. Defaults to `4140` |
-| LIGHTSTEP_SSL_VERIFY_PEER | If using 443 as the port, toggle SSL verification. Defaults to true. |
-| LIGHTSTEP_VERBOSITY | The verbosity level of lightstep logs. Defaults to 1. |
+| LIGHTSTEP_ENABLED | Flag to determine whether to broadcast spans. Defaults to (1) enabled, 0 will disable.| 1 |
+| LIGHTSTEP_COMPONENT_NAME | The component name to use | '' | 
+| LIGHTSTEP_ACCESS_TOKEN | The access token to use to connect to the collector | '' | 
+| LIGHTSTEP_HOST | Host of the collector. | `lightstep-collector.linkerd` |
+| LIGHTSTEP_PORT | Port of the collector. | `4140` |
+| LIGHTSTEP_SSL_VERIFY_PEER | If using 443 as the port, toggle SSL verification. | true |
+| LIGHTSTEP_MAX_BUFFERED_SPANS | The maximum number of spans to buffer before dropping. | `1_000` |
+| LIGHTSTEP_MAX_LOG_RECORDS | Maximum number of log records on a span to accept. | `1_000` |
+| LIGHTSTEP_MAX_REPORTING_INTERVAL_SECONDS | The maximum number of seconds to wait before flushing the report to the collector. | 3.0 |
+| LIGHTSTEP_VERBOSITY | The verbosity level of lightstep logs. | 1 |
 
 Most systems will only need to customize the component name.
 

--- a/bc-lightstep-ruby.gemspec
+++ b/bc-lightstep-ruby.gemspec
@@ -35,6 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'pry'
 
-  spec.add_runtime_dependency 'lightstep', '~> 0.11.2'
+  spec.add_runtime_dependency 'lightstep', '~> 0.13.0'
   spec.add_runtime_dependency 'faraday', '~> 0.8'
 end

--- a/lib/bigcommerce/lightstep/configuration.rb
+++ b/lib/bigcommerce/lightstep/configuration.rb
@@ -35,6 +35,9 @@ module Bigcommerce
         verbosity: 1,
         http1_error_code: 500,
         http1_error_code_minimum: 500,
+        max_buffered_spans: 1_000,
+        max_log_records: 1_000,
+        max_reporting_interval_seconds: 3.0,
         enabled: true
       }.freeze
 
@@ -91,6 +94,11 @@ module Bigcommerce
         self.host = ENV.fetch('LIGHTSTEP_HOST', 'lightstep-collector.linkerd')
         self.port = ENV.fetch('LIGHTSTEP_PORT', 4140).to_i
         self.ssl_verify_peer = ENV.fetch('LIGHTSTEP_SSL_VERIFY_PEER', true)
+
+        self.max_buffered_spans = ENV.fetch('LIGHTSTEP_MAX_BUFFERED_SPANS', 1_000).to_i
+        self.max_log_records = ENV.fetch('LIGHTSTEP_MAX_LOG_RECORDS', 1_000).to_i
+        self.max_reporting_interval_seconds = ENV.fetch('LIGHTSTEP_MAX_REPORTING_INTERVAL_SECONDS', 3.0).to_f
+
         self.verbosity = ENV.fetch('LIGHTSTEP_VERBOSITY', 1).to_i
         self.logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
         self.enabled = ENV.fetch('LIGHTSTEP_ENABLED', 1).to_i > 0

--- a/lib/bigcommerce/lightstep/middleware/faraday.rb
+++ b/lib/bigcommerce/lightstep/middleware/faraday.rb
@@ -75,8 +75,8 @@ module Bigcommerce
         #
         def inject_ot_tags!(request_env, span)
           request_env[:request_headers].merge!(
-            OT_TAG_TRACE_ID => span.span_context.trace_id.to_s,
-            OT_TAG_SPAN_ID  => span.span_context.id.to_s,
+            OT_TAG_TRACE_ID => span.context.trace_id.to_s,
+            OT_TAG_SPAN_ID  => span.context.id.to_s,
             OT_TAG_SAMPLED  => 'true'
           )
         end

--- a/spec/bigcommerce/lightstep_spec.rb
+++ b/spec/bigcommerce/lightstep_spec.rb
@@ -22,17 +22,28 @@ describe Bigcommerce::Lightstep do
   let(:component_name) { 'foo' }
 
   describe '#start' do
+    let(:max_buffered_spans) { Bigcommerce::Lightstep.max_buffered_spans }
+    let(:max_log_records) { Bigcommerce::Lightstep.max_log_records }
+    let(:max_reporting_interval_seconds) { Bigcommerce::Lightstep.max_reporting_interval_seconds }
+
     subject { described_class.start(transport_factory: transport_factory, component_name: component_name) }
 
     before do
       allow(transport_factory).to receive(:build).and_return(transport)
+      allow_any_instance_of(LightStep::Reporter).to receive(:reset_on_fork)
     end
 
     it 'should properly configure lightstep' do
       expect(::LightStep).to receive(:configure).with(
         component_name: component_name,
         transport: transport
-      )
+      ).and_call_original
+
+      expect(LightStep.instance).to receive(:max_span_records=).with(max_buffered_spans)
+      expect(LightStep.instance.max_span_records).to eq max_buffered_spans
+      expect(LightStep.instance).to receive(:max_log_records=).with(max_log_records)
+      expect(LightStep.instance.max_log_records).to eq max_log_records
+      expect(LightStep.instance).to receive(:report_period_seconds=).with(max_reporting_interval_seconds)
       subject
     end
   end


### PR DESCRIPTION
## What?

- Adds LIGHTSTEP_MAX_BUFFERED_SPANS config ENV + setting for maximum number of spans to buffer
- Adds LIGHTSTEP_MAX_LOG_RECORDS config ENV + setting for maximum number of log records that can be on a span
- Adds LIGHTSTEP_MAX_REPORTING_INTERVAL_SECONDS config ENV + setting for max reporting flush interval to collector

Bumps lightstep gem to 0.13.0.

## How was it tested?

Tested on a few various services, spans come in as expected, can successfully adjust reporting periods.

----

@bigcommerce/platform-engineering @pedelman @zackangelo @zvuki 
