### PR TITLE
PEN-1088: Fix issue where unitialized reporters can cause a NoMethodError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ sudo: false
 dist: trusty
 rvm:
   - 2.2
-  - 2.3
   - 2.4
+  - 2.5
 before_install: gem install bundler -v 1.15.1
 script: ./.travis.sh
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ Changelog for the bc-lightstep-ruby gem.
 
 h3. Pending Release
 
+h3. 1.2.1
+
+- Fix issue where in Rails controllers before the action occurs that an uninitialized reporter would cause a
+  NoMethodError to occur (this most commonly occurs in test suites)
+
 h3. 1.2.0
 
 - Bump lightstep gem to 0.13

--- a/lib/bigcommerce/lightstep/middleware/faraday.rb
+++ b/lib/bigcommerce/lightstep/middleware/faraday.rb
@@ -76,8 +76,8 @@ module Bigcommerce
         def inject_ot_tags!(request_env, span)
           request_env[:request_headers].merge!(
             OT_TAG_TRACE_ID => span.context.trace_id.to_s,
-            OT_TAG_SPAN_ID  => span.context.id.to_s,
-            OT_TAG_SAMPLED  => 'true'
+            OT_TAG_SPAN_ID => span.context.id.to_s,
+            OT_TAG_SAMPLED => 'true'
           )
         end
 

--- a/lib/bigcommerce/lightstep/rails_controller_instrumentation.rb
+++ b/lib/bigcommerce/lightstep/rails_controller_instrumentation.rb
@@ -33,7 +33,7 @@ module Bigcommerce
             span.set_tag('error', true)
             span.set_tag('http.status_code', Bigcommerce::Lightstep.http1_error_code)
             tracer.clear_active_span!
-            span.finish
+            span.finish if tracer.reporter_initialized? # only finish the span if we're actually reporting
             raise # re-raise the error
           end
           span.set_tag('http.status_code', response.status)


### PR DESCRIPTION
## What?

When using the `RailsControllerInstrumentation` module, if the reporter is uninitialized (which can happen in test suites, for example), and an exception occurs in a controller, bc-lightstep-ruby will currently 500 with a NoMethodError. 

This is due to a missed check in lightstep-tracer-ruby's Span class where it is not checking for the presence of the `@reporter` instance variable before calling `add_span` on it. In order to mitigate against this, we should first check to ensure the reporter is initialized before attempting to finish the span. We do a similar approach in the normal add_span calls elsewhere.

----

@bigcommerce/platform-engineering @jmwiese 