### PR TITLE
PEN-1135: Allow for usage of blank access tokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ cache:
 sudo: false
 dist: trusty
 rvm:
-  - 2.2
   - 2.4
   - 2.5
-before_install: gem install bundler -v 1.15.1
+bundler_args: --without production
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 script: ./.travis.sh
 env:
   matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the bc-lightstep-ruby gem.
 
 h3. Pending Release
 
+- Allow for usage of blank access tokens, which can be used with disabled token checking + project-specific satellites
+
 h3. 1.2.1
 
 - Fix issue where in Rails controllers before the action occurs that an uninitialized reporter would cause a

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ bc-lightstep-ruby can be automatically configured from these ENV vars, if you'd 
 | ---- | ----------- |
 | LIGHTSTEP_ENABLED | Flag to determine whether to broadcast spans. Defaults to (1) enabled, 0 will disable.| 1 |
 | LIGHTSTEP_COMPONENT_NAME | The component name to use | '' | 
-| LIGHTSTEP_ACCESS_TOKEN | The access token to use to connect to the collector | '' | 
+| LIGHTSTEP_ACCESS_TOKEN | The access token to use to connect to the collector. Optional. | '' | 
 | LIGHTSTEP_HOST | Host of the collector. | `lightstep-collector.linkerd` |
 | LIGHTSTEP_PORT | Port of the collector. | `4140` |
 | LIGHTSTEP_SSL_VERIFY_PEER | If using 443 as the port, toggle SSL verification. | true |

--- a/lib/bigcommerce/lightstep/transport.rb
+++ b/lib/bigcommerce/lightstep/transport.rb
@@ -62,11 +62,6 @@ module Bigcommerce
         @read_timeout = read_timeout.to_i
         @continue_timeout = continue_timeout
         @keep_alive_timeout = keep_alive_timeout.to_i
-
-        raise ::Bigcommerce::Lightstep::Errors::InvalidAccessToken, 'access_token must be a string' unless access_token.is_a?(String)
-
-        raise ::Bigcommerce::Lightstep::Errors::InvalidAccessToken, 'access_token cannot be blank'  if access_token.empty?
-
         @access_token = access_token.to_s
         @logger = logger || ::Logger.new(STDOUT)
       end
@@ -96,7 +91,7 @@ module Bigcommerce
       #
       def build_request(report)
         req = Net::HTTP::Post.new(REPORTS_API_ENDPOINT)
-        req[HEADER_ACCESS_TOKEN] = @access_token
+        req[HEADER_ACCESS_TOKEN] = @access_token unless @access_token.to_s.empty?
         req['Content-Type'] = 'application/json'
         req['Connection'] = 'keep-alive'
         req.body = report.to_json

--- a/spec/bigcommerce/lightstep/transport_spec.rb
+++ b/spec/bigcommerce/lightstep/transport_spec.rb
@@ -36,21 +36,6 @@ describe Bigcommerce::Lightstep::Transport do
         expect(subject).to be_a(described_class)
       end
     end
-
-    context 'if the access token is not a string' do
-      let(:access_token) { 213 }
-
-      it 'should raise a ::Bigcommerce::Lightstep::Errors::InvalidAccessToken exception' do
-        expect { subject }.to raise_error(::Bigcommerce::Lightstep::Errors::InvalidAccessToken)
-      end
-    end
-
-    context 'if the access token is blank' do
-      let(:access_token) { '' }
-      it 'should raise a ::Bigcommerce::Lightstep::Errors::InvalidAccessToken exception' do
-        expect { subject }.to raise_error(::Bigcommerce::Lightstep::Errors::InvalidAccessToken)
-      end
-    end
   end
 
   describe '.report' do


### PR DESCRIPTION
## What?

Allows usage of blank access tokens,  which can be used with satellites that have disabled token checking and are using project-specific keys.

----

@bigcommerce/platform-engineering 