### PR TITLE
feat(platform): PEN-1139 - Adds ability to span redis timings

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,6 +8,9 @@
 Metrics/AbcSize:
   Max: 147
 
+Metrics/BlockLength:
+  Max: 80
+
 Metrics/BlockNesting:
   Max: 4
 
@@ -26,7 +29,6 @@ Metrics/PerceivedComplexity:
 Metrics/LineLength:
   Enabled: false
 
-# Offense count: 63
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
   Max: 88

--- a/.travis.sh
+++ b/.travis.sh
@@ -5,7 +5,7 @@ if [ "$TEST_GROUP" == "prereq" ]
 then
   bundle exec bundle-audit update
   bundle exec bundle-audit check -v
-  bundle exec rubocop
+  bundle exec rubocop -P
 
 elif [ "$TEST_GROUP"  == "1" ]
 then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Changelog for the bc-lightstep-ruby gem.
 
 h3. Pending Release
 
-
+- Add Redis instrumentation support
 
 h3. 1.2.2
 

--- a/lib/bigcommerce/lightstep.rb
+++ b/lib/bigcommerce/lightstep.rb
@@ -23,6 +23,7 @@ require_relative 'lightstep/transport_factory'
 require_relative 'lightstep/transport'
 require_relative 'lightstep/rails_controller_instrumentation'
 require_relative 'lightstep/middleware/faraday'
+require_relative 'lightstep/redis/tracer'
 
 ##
 # Main base module
@@ -44,6 +45,8 @@ module Bigcommerce
       ::LightStep.instance.max_span_records = ::Bigcommerce::Lightstep.max_buffered_spans
       ::LightStep.instance.max_log_records = ::Bigcommerce::Lightstep.max_log_records
       ::LightStep.instance.report_period_seconds = ::Bigcommerce::Lightstep.max_reporting_interval_seconds
+
+      ::Bigcommerce::Lightstep::Redis::Wrapper.patch if ::Bigcommerce::Lightstep.enabled
     end
   end
 end

--- a/lib/bigcommerce/lightstep/redis/tracer.rb
+++ b/lib/bigcommerce/lightstep/redis/tracer.rb
@@ -1,0 +1,66 @@
+# Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require_relative 'wrapper'
+
+module Bigcommerce
+  module Lightstep
+    module Redis
+      ##
+      # Middleware tracer for Redis clients
+      #
+      class Tracer
+        ##
+        # @param [String] key
+        # @param [String] statement
+        # @param [String] instance
+        # @param [String] host
+        # @param [Integer] port
+        #
+        def trace(key:, statement:, instance:, host:, port:)
+          return yield unless tracer
+
+          tags = {
+            'db.type' => 'redis',
+            'db.statement' => statement.to_s.split(' ').first, # only take the command, not any arguments
+            'db.instance' => instance,
+            'db.host' => "redis://#{host}:#{port}",
+            'span.kind' => 'client'
+          }
+
+          tracer.start_span(key) do |span|
+            tags.each do |k, v|
+              span.set_tag(k, v)
+            end
+            begin
+              resp = yield
+            rescue StandardError => _
+              span.set_tag('error', true)
+              raise # re-raise the error
+            end
+            resp
+          end
+        end
+
+        ##
+        # @return [::Bigcommerce::Lightstep::Tracer]
+        #
+        def tracer
+          @tracer ||= ::Bigcommerce::Lightstep::Tracer.instance
+        end
+      end
+    end
+  end
+end

--- a/lib/bigcommerce/lightstep/redis/wrapper.rb
+++ b/lib/bigcommerce/lightstep/redis/wrapper.rb
@@ -1,0 +1,84 @@
+# Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Bigcommerce
+  module Lightstep
+    module Redis
+      ##
+      # Instrumentation wrapper for Redis
+      #
+      module Wrapper
+        class << self
+          def patch
+            require 'redis' # thread and fork safety
+            return if @wrapped
+
+            wrap unless @wrapped
+            @wrapped = true
+          rescue ::LoadError => _
+            @wrapped = false
+            # noop
+          end
+
+          private
+
+          def wrap
+            raise ::LoadError, 'Redis not loaded' unless defined?(::Redis::Client)
+
+            ::Redis::Client.class_eval do
+              alias_method :call_original, :call
+              alias_method :call_pipeline_original, :call_pipeline
+
+              def call(command)
+                return call_original(command) unless bc_lightstep_tracer
+
+                bc_lightstep_tracer.trace(
+                  key: "redis.#{command[0]}",
+                  statement: command.join(' '),
+                  instance: db,
+                  host: host,
+                  port: port
+                ) do
+                  call_original(command)
+                end
+              end
+
+              def call_pipeline(pipeline)
+                return call_pipeline_original(pipeline) unless bc_lightstep_tracer
+
+                bc_lightstep_tracer.trace(
+                  key: 'redis.pipelined',
+                  statement: commands.empty? ? '' : commands.map { |arr| arr.join(' ') }.join(', '),
+                  instance: db,
+                  host: host,
+                  port: port
+                ) do
+                  call_pipeline_original(pipeline)
+                end
+              end
+
+              ##
+              # @return [::Bigcommerce::Lightstep::Redis::Tracer]
+              #
+              def bc_lightstep_tracer
+                @bc_lightstep_tracer ||= ::Bigcommerce::Lightstep::Redis::Tracer.new
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/bigcommerce/lightstep/redis/tracer_spec.rb
+++ b/spec/bigcommerce/lightstep/redis/tracer_spec.rb
@@ -1,0 +1,83 @@
+# Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+class TestRedisTracerCaller
+  def foo
+    true
+  end
+end
+
+describe Bigcommerce::Lightstep::Redis::Tracer do
+  let(:tracer) { described_class.new }
+
+  before do
+    allow(::Bigcommerce::Lightstep::Tracer).to receive(:instance).and_return(mock_tracer)
+  end
+
+  describe '.trace' do
+    let(:key) { 'redis.get' }
+    let(:statement) { 'get key123' }
+    let(:instance) { 1 }
+    let(:host) { 'redis.service' }
+    let(:port) { 6379 }
+    let(:caller) { TestRedisTracerCaller.new }
+
+    subject do
+      tracer.trace(key: key, statement: statement, instance: instance, host: host, port: port) do
+        caller.foo
+      end
+    end
+
+    context 'if the trace is successful' do
+      it 'should trace the result' do
+        expect(mock_tracer).to receive(:start_span).with(key).and_call_original
+        expect(mock_tracer.span).to receive(:set_tag).with('db.type', 'redis').ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('db.statement', 'get').ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('db.instance', instance).ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('db.host', "redis://#{host}:#{port}").ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('span.kind', 'client').ordered
+
+        expect(caller).to receive(:foo).once
+
+        subject
+      end
+    end
+
+    context 'if the trace raises an exception' do
+      let(:exception) { StandardError.new('Oh noes') }
+
+      before do
+        allow(caller).to receive(:foo).and_raise(exception)
+      end
+
+      it 'should trace the result and add an error tag to the span' do
+        expect(mock_tracer).to receive(:start_span).with(key).and_call_original
+        expect(mock_tracer.span).to receive(:set_tag).with('db.type', 'redis').ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('db.statement', 'get').ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('db.instance', instance).ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('db.host', "redis://#{host}:#{port}").ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('span.kind', 'client').ordered
+
+        expect(mock_tracer.span).to receive(:set_tag).with('error', true).ordered
+
+        expect(caller).to receive(:foo).once
+
+        expect { subject }.to raise_error(exception)
+      end
+    end
+  end
+end

--- a/spec/support/mock_tracer.rb
+++ b/spec/support/mock_tracer.rb
@@ -13,11 +13,34 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
+
 module Bigcommerce
   module Lightstep
-    module SpecHelpers
-      def mock_tracer
-        @mock_tracer ||= Bigcommerce::Lightstep::MockTracer.new
+    class MockTracer
+      def start_span(_key, _options = {})
+        yield span
+      end
+
+      def span
+        @span ||= Bigcommerce::Lightstep::MockSpan.new
+      end
+
+      def clear_active_span!
+        true
+      end
+
+      def reporter_initialized?
+        true
+      end
+    end
+
+    class MockSpan
+      def set_tag(_key, _value)
+        true
+      end
+
+      def finish
+        true
       end
     end
   end


### PR DESCRIPTION
## What?

Adds the ability to span redis timings for all redis commands. Adds as tags the host, port, db, and the command being logged (but not the args).

----

@bigcommerce/ruby @bigcommerce/platform-engineering 