### PR TITLE
Updates gemspec to allow for newer versions of faraday gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,16 @@ Changelog for the bc-lightstep-ruby gem.
 
 h3. Pending Release
 
-h3. 1.3.1
-
-- Add various options to suppress redis trace spam
-- Fix issue with pipeline commands in redis instrumentation
+- Updates gemspec to allow for newer Faraday versions
 
 h3. 1.3.2
 
 - Fix compatibility issues with resque-scheduler and redis instrumentation
+
+h3. 1.3.1
+
+- Add various options to suppress redis trace spam
+- Fix issue with pipeline commands in redis instrumentation
 
 h3. 1.3.0
 

--- a/bc-lightstep-ruby.gemspec
+++ b/bc-lightstep-ruby.gemspec
@@ -36,5 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
 
   spec.add_runtime_dependency 'lightstep', '~> 0.13.0'
-  spec.add_runtime_dependency 'faraday', '~> 0.8'
+  spec.add_runtime_dependency 'faraday', ['>= 0.8', '<= 0.15.4']
 end


### PR DESCRIPTION
chore(PBY-616): updates Gemspec to allow for newer versions of faraday gem

* Reviewed the change log for the Faraday gem here:
https://github.com/lostisland/faraday/releases
* Updated to use Faraday 0.15.4 and all specs pass
