### PR TITLE
Add `hostname` preset for env var injection into spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the bc-lightstep-ruby gem.
 
 h3. Pending Release
 
+- Add `hostname` preset for env var injection into spans
+
 h3. 1.5.0
 
 - Add interceptors that allow for global injection of tags into spans

--- a/lib/bigcommerce/lightstep/interceptors/env.rb
+++ b/lib/bigcommerce/lightstep/interceptors/env.rb
@@ -31,6 +31,10 @@ module Bigcommerce
           'provider.datacenter': 'NOMAD_DC'
         }.freeze
 
+        PRESET_HOSTNAME = {
+          'hostname': 'HOSTNAME',
+        }.freeze
+
         ##
         # @param [Hash] keys A hash of span->env key mappings
         # @param [ENV] env The ENV class to get variables from
@@ -63,6 +67,8 @@ module Bigcommerce
         def augment_keys_with_presets!
           @presets.each do |preset|
             case preset
+            when :hostname
+              @keys.merge!(PRESET_HOSTNAME)
             when :nomad
               @keys.merge!(PRESET_NOMAD)
             end

--- a/spec/bigcommerce/lightstep/interceptors/env_spec.rb
+++ b/spec/bigcommerce/lightstep/interceptors/env_spec.rb
@@ -55,6 +55,21 @@ describe Bigcommerce::Lightstep::Interceptors::Env do
         end
       end
 
+      context 'with the hostname preset' do
+        let(:presets) { [:hostname] }
+        let(:keys) { {} }
+        let(:env) do
+          {
+              'HOSTNAME' => 'asdf1234',
+          }
+        end
+
+        it 'should set the appropriate nomad tags' do
+          expect(span).to receive(:set_tag).with('hostname', 'asdf1234').once.ordered
+          subject
+        end
+      end
+
       context 'with the nomad preset' do
         let(:presets) { [:nomad] }
         let(:keys) { {} }


### PR DESCRIPTION
Adds a new preset for injecting the container hostname globally into spans.

----

@jmwiese @bigcommerce/platform-engineering @bigcommerce/ruby 