### PR TITLE
Add create_a_lightstep_span rspec matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the bc-lightstep-ruby gem.
 
 h3. Pending Release
 
+- Add rspec helper for testing custom lightstep spans
+
 h3. 1.5.1
 
 - Add `hostname` preset for env var injection into spans

--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ re-enable this by setting the `redis_allow_root_spans` configuration option to `
 It also excludes `ping` commands, and you can provide a custom list by setting the `redis_excluded_commands` 
 configuration option to an array of commands to exclude.
 
+## RSpec
+
+This library comes with a built-in matcher for testing span blocks. In your rspec config:
+
+```ruby
+require 'bigcommerce/lightstep/rspec'
+```
+
+Then, in a test:
+
+```ruby
+it 'should create a lightstep span' do
+  expect { my_code_here }.to create_a_lightstep_span(name: 'my-span-name', tags: { tag_one: 'value-here' })
+end
+```
+
 ## License
 
 Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved 

--- a/lib/bigcommerce/lightstep/rspec.rb
+++ b/lib/bigcommerce/lightstep/rspec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+begin
+  require 'rspec/core'
+  require 'rspec/expectations'
+  BC_LIGHTSTEP_RSPEC_NAMESPACE = RSpec
+  BC_LIGHTSTEP_RSPEC_RUNNER = RSpec
+rescue LoadError # old rspec compat
+  require 'spec'
+  BC_LIGHTSTEP_RSPEC_NAMESPACE = Spec
+  BC_LIGHTSTEP_RSPEC_RUNNER = Spec::Runner
+end
+
+module Bigcommerce
+  module Lightstep
+    ##
+    # RSpec helper for lightstep traces
+    #
+    module RspecHelpers
+      def lightstep_tracer
+        ::Bigcommerce::Lightstep::Tracer.instance
+      end
+    end
+  end
+end
+
+##
+# Usage:
+#   expect { my_code_here }.to create_a_lightstep_span(name: 'my-span-name', tags: { tag_one: 'value-here' })
+#
+BC_LIGHTSTEP_RSPEC_NAMESPACE::Matchers.define :create_a_lightstep_span do |opts|
+  match(notify_expectation_failures: true) do |proc|
+    span_name = opts.fetch(:name)
+    lightstep_span = ::LightStep::Span.new(
+      tracer: ::Bigcommerce::Lightstep::Tracer.instance,
+      operation_name: span_name,
+      max_log_records: 0,
+      start_micros: 0
+    )
+    expect(::Bigcommerce::Lightstep::Tracer.instance).to receive(:start_span).with(span_name).and_yield(lightstep_span).ordered
+    opts.fetch(:tags, {}).each do |key, value|
+      expect(lightstep_span).to receive(:set_tag).with(key.to_s, value)
+    end
+    proc.call
+  end
+  supports_block_expectations
+end
+
+BC_LIGHTSTEP_RSPEC_RUNNER.configure do |config|
+  config.include Bigcommerce::Lightstep::RspecHelpers
+  config.before do
+    # provide a dummy span for noop calls
+    lightstep_span = ::LightStep::Span.new(
+      tracer: ::Bigcommerce::Lightstep::Tracer.instance,
+      operation_name: 'default',
+      max_log_records: 0,
+      start_micros: 0
+    )
+    allow(::Bigcommerce::Lightstep::Tracer.instance).to receive(:start_span).and_yield(lightstep_span)
+  end
+end


### PR DESCRIPTION
## What?

Adds a custom rspec matcher that can be used by services to easily test for custom spans.

```ruby
expect { my_code_here }.to create_a_lightstep_span(name: 'my-span-name', tags: { tag_one: 'value-here' })
```

----

@bigcommerce/platform-engineering @jmwiese @bigcommerce/ruby 