### PR TITLE
Pre-materialize tag values for ENV interceptor at initialization to reduce CPU usage per-span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the bc-lightstep-ruby gem.
 
 h3. Pending Release
 
+- Allow for instantiation of interceptors at initialization time
+- Pre-build tag values for ENV interceptor at initialization to reduce CPU usage per-span
+
 h3. 1.5.2
 
 - Add rspec helper for testing custom lightstep spans

--- a/README.md
+++ b/README.md
@@ -102,6 +102,44 @@ it 'should create a lightstep span' do
 end
 ```
 
+## Global Interceptors
+
+This library has global interceptor support that will allow access to each span as it is built. This allows you to
+dynamically inject tags or alter spans as they are collected. You can configure interceptors via an initializer:
+
+```ruby
+Bigcommerce::Lightstep.configure do |c|
+  c.interceptors.use(MyInterceptor, an_option: 123)
+  # or, alternatively:
+  c.interceptors.use(MyInterceptor.new(an_option: 123)) 
+end
+```
+
+It's important to note that this is a CPU-intensive operation as interceptors will be run for every `start_span` tag,
+so don't build interceptors that require lots of processing power or that would impact latencies.
+
+### ENV Interceptor
+
+Provided out of the box is an interceptor to automatically inject ENV vars into span tags. You can configure like so:
+
+```ruby
+
+Bigcommerce::Lightstep.configure do |c|
+  c.interceptors.use(::Bigcommerce::Lightstep::Interceptors::Env.new(
+    keys: {
+      version: 'VERSION'
+    },
+    presets: [:nomad, :hostname]
+  ))
+end
+```
+
+The `keys` argument allows you to pass a `span tag => ENV key` mapping that will assign those ENV vars to spans. The
+`presets` argument comes with a bunch of preset mappings you can use rather than manually mapping them yourself.
+
+Note that this interceptor _must_ be instantiated in configuration, rather than passing the class and options,
+as it needs to pre-materialize the ENV values to reduce CPU usage. 
+
 ## License
 
 Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved 

--- a/lib/bigcommerce/lightstep/interceptors/registry.rb
+++ b/lib/bigcommerce/lightstep/interceptors/registry.rb
@@ -29,8 +29,8 @@ module Bigcommerce
         ##
         # Add to the thread-safe registry
         #
-        # @param [Class] klass The class to add
-        # @param [Hash] options A hash of options to pass into the class during initialization
+        # @param [Class|Object] klass The class to add or object to register.
+        # @param [Hash] options (Optional) A hash of options to pass into the class during initialization
         #
         def use(klass, options = {})
           registry_mutex do
@@ -85,7 +85,9 @@ module Bigcommerce
         #
         def list
           registry_mutex do
-            @registry.map { |h| h[:klass] }
+            @registry.map do |h|
+              h[:klass].instance_of?(Class) ? h[:klass] : h[:klass].class
+            end
           end
         end
 
@@ -95,13 +97,11 @@ module Bigcommerce
         # @return [Array<Object>]
         #
         def all
-          is = []
           registry_mutex do
-            @registry.each do |o|
-              is << o[:klass].new(o[:options])
+            @registry.map do |o|
+              o[:klass].is_a?(Class) ? o[:klass].new(o[:options]) : o[:klass]
             end
           end
-          is
         end
 
         private

--- a/spec/bigcommerce/lightstep/interceptors/env_spec.rb
+++ b/spec/bigcommerce/lightstep/interceptors/env_spec.rb
@@ -31,7 +31,7 @@ describe Bigcommerce::Lightstep::Interceptors::Env do
     }
   end
   let(:presets) { [] }
-  let(:interceptor) { described_class.new(keys: keys, env: env, presets: presets)}
+  let(:interceptor) { described_class.new(keys: keys, env: env, presets: presets) }
   let(:span) { double(:span, set_tag: true) }
 
   describe '.call' do
@@ -43,6 +43,14 @@ describe Bigcommerce::Lightstep::Interceptors::Env do
           expect(span).to receive(:set_tag).with('git.sha', '770ecc256e414c81344caa78eaa0c9272a375c71').once.ordered
           expect(span).to receive(:set_tag).with('provider.datacenter', 'us-central1-a').once.ordered
           subject
+        end
+
+        it 'should only collect the tags once even with multiple calls' do
+          expect(env).to receive(:fetch).with('GIT_SHA', nil).once.ordered
+          expect(env).to receive(:fetch).with('DATACENTER', nil).once.ordered
+          interceptor.call(span: span) { true }
+          interceptor.call(span: span) { true }
+          interceptor.call(span: span) { true }
         end
       end
 


### PR DESCRIPTION
The ENV interceptor is currently collecting and parsing values from ENV per-span. This changes it to only collect and parse the values during initialization, and only add the tags to the span in the actual span block.

----

@bigcommerce/platform-engineering @jmwiese @pedelman @mattolson 