### PR TITLE
Add service.version to lightstep tags

### DIFF
--- a/lib/bigcommerce/lightstep.rb
+++ b/lib/bigcommerce/lightstep.rb
@@ -43,9 +43,12 @@ module Bigcommerce
       component_name ||= ::Bigcommerce::Lightstep.component_name
       transport_factory ||= ::Bigcommerce::Lightstep::TransportFactory.new
       ::LightStep.logger = logger
+      tags = {}
+      tags['service.version'] = ::Bigcommerce::Lightstep.release unless ::Bigcommerce::Lightstep.release.empty?
       ::LightStep.configure(
         component_name: component_name,
-        transport: transport_factory.build
+        transport: transport_factory.build,
+        tags: tags
       )
       ::LightStep.instance.max_span_records = ::Bigcommerce::Lightstep.max_buffered_spans
       ::LightStep.instance.max_log_records = ::Bigcommerce::Lightstep.max_log_records

--- a/lib/bigcommerce/lightstep/configuration.rb
+++ b/lib/bigcommerce/lightstep/configuration.rb
@@ -113,12 +113,33 @@ module Bigcommerce
       ##
       # Automatically determine environment
       #
+      # @return [String]
+      #
       def environment
         if defined?(Rails)
           Rails.env
         else
-          ENV['RACK_ENV'] || ENV['RAILS_ENV'] || 'development'
+          env['RACK_ENV'] || env['RAILS_ENV'] || 'development'
         end
+      end
+
+      ##
+      # @return [String]
+      #
+      def release
+        unless @release
+          app_name = env.fetch('LIGHTSTEP_APP_NAME', env.fetch('NOMAD_JOB_NAME', '')).to_s
+          sha = env.fetch('LIGHTSTEP_RELEASE_SHA', env.fetch('NOMAD_META_RELEASE_SHA', '')).to_s
+          default_release = app_name.empty? && sha.empty? ? '' : "#{app_name}@#{sha}"
+          @release = env.fetch('LIGHTSTEP_RELEASE', default_release).to_s
+        end
+        @release
+      end
+
+      private
+
+      def env
+        ENV
       end
     end
   end

--- a/spec/bigcommerce/lightstep_spec.rb
+++ b/spec/bigcommerce/lightstep_spec.rb
@@ -36,7 +36,8 @@ describe Bigcommerce::Lightstep do
     it 'should properly configure lightstep' do
       expect(::LightStep).to receive(:configure).with(
         component_name: component_name,
-        transport: transport
+        transport: transport,
+        tags: {}
       ).and_call_original
 
       expect(LightStep.instance).to receive(:max_span_records=).with(max_buffered_spans)


### PR DESCRIPTION
Adds `service.version` to Lightstep tags, gathering that value from ENV.

Compiles it as `app_name@sha` to allow for global releases by grouped applications with multiple runtimes.

----

@jmwiese @bigcommerce/platform-engineering 