### PR TITLE
Add NOMAD_NODE_ID, NOMAD_NODE_NAME as lightstep span tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the bc-lightstep-ruby gem.
 
 h3. Pending Release
 
+- Add `nomad.node.id` and `nomad.node.name` span tags via ENV mappings
+
 h3. 1.6.3
 
 - Add service.version to tags

--- a/lib/bigcommerce/lightstep/interceptors/env.rb
+++ b/lib/bigcommerce/lightstep/interceptors/env.rb
@@ -26,6 +26,8 @@ module Bigcommerce
           'container.cpu': 'NOMAD_CPU_LIMIT',
           'container.mem': 'NOMAD_MEMORY_LIMIT',
           'git.sha': 'NOMAD_META_SHA',
+          'nomad.node.id': 'NOMAD_NODE_ID',
+          'nomad.node.name': 'NOMAD_NODE_NAME',
           'nomad.task_name': 'NOMAD_TASK_NAME',
           'provider.region': 'NOMAD_REGION',
           'provider.datacenter': 'NOMAD_DC'

--- a/spec/bigcommerce/lightstep/interceptors/env_spec.rb
+++ b/spec/bigcommerce/lightstep/interceptors/env_spec.rb
@@ -91,6 +91,8 @@ describe Bigcommerce::Lightstep::Interceptors::Env do
               'NOMAD_CPU_LIMIT' => '128',
               'NOMAD_MEMORY_LIMIT' => '512',
               'NOMAD_META_SHA' => '770ecc256e414c81344caa78eaa0c9272a375c71',
+              'NOMAD_NODE_ID' => 'asdf1234',
+              'NOMAD_NODE_NAME' => 'nomad-client-abc789',
               'NOMAD_TASK_NAME' => 'foo-bar',
               'NOMAD_REGION' => 'us',
               'NOMAD_DC' => 'us-central1-a'
@@ -101,6 +103,8 @@ describe Bigcommerce::Lightstep::Interceptors::Env do
           expect(span).to receive(:set_tag).with('container.cpu', '128').once.ordered
           expect(span).to receive(:set_tag).with('container.mem', '512').ordered
           expect(span).to receive(:set_tag).with('git.sha', '770ecc256e414c81344caa78eaa0c9272a375c71').ordered
+          expect(span).to receive(:set_tag).with('nomad.node.id', 'asdf1234').ordered
+          expect(span).to receive(:set_tag).with('nomad.node.name', 'nomad-client-abc789').ordered
           expect(span).to receive(:set_tag).with('nomad.task_name', 'foo-bar').ordered
           expect(span).to receive(:set_tag).with('provider.region', 'us').ordered
           expect(span).to receive(:set_tag).with('provider.datacenter', 'us-central1-a').ordered


### PR DESCRIPTION
Adds two new env vars for the nomad ENV span injection interceptor:

* `NOMAD_NODE_ID`
* `NOMAD_NODE_NAME`

This allows tracking performance per nomad client.

----

@bigcommerce/platform-engineering @jmwiese @zvuki 