### PR TITLE
Add automatic ActiveRecord mysql span tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for the bc-lightstep-ruby gem.
 
 ### Pending Release
 
+### 2.1.0
+
+- Add support for automatically-generated mysql spans in tracing
+
 ### 2.0.0
 
 - Drop support for Ruby < 2.6

--- a/README.md
+++ b/README.md
@@ -45,10 +45,18 @@ bc-lightstep-ruby can be automatically configured from these ENV vars, if you'd 
 | LIGHTSTEP_ACCESS_TOKEN | The access token to use to connect to the collector. Optional. | '' | 
 | LIGHTSTEP_HOST | Host of the collector. | `lightstep-collector.linkerd` |
 | LIGHTSTEP_PORT | Port of the collector. | `4140` |
+| LIGHTSTEP_HTTP1_ERROR_CODE | The HTTP error code to report in spans for internal errors | 500 |
+| LIGHTSTEP_HTTP1_ERROR_CODE_MINIMUM | The minimum HTTP error code value to be considered an error for span tag purposes. | 500 |
+| LIGHTSTEP_CONTROLLER_PREFIX | The prefix for Rails controllers to use | `controllers.` |
 | LIGHTSTEP_SSL_VERIFY_PEER | If using 443 as the port, toggle SSL verification. | true |
 | LIGHTSTEP_MAX_BUFFERED_SPANS | The maximum number of spans to buffer before dropping. | `1_000` |
 | LIGHTSTEP_MAX_LOG_RECORDS | Maximum number of log records on a span to accept. | `1_000` |
 | LIGHTSTEP_MAX_REPORTING_INTERVAL_SECONDS | The maximum number of seconds to wait before flushing the report to the collector. | 3.0 |
+| LIGHTSTEP_ACTIVE_RECORD_ENABLED | Whether or not to add ActiveRecord mysql spans. Only works with mysql2 gem. | 1 |
+| LIGHTSTEP_ACTIVE_RECORD_ALLOW_AS_ROOT_SPAN | Allow ActiveRecord mysql spans to be the root span? | 0 |
+| LIGHTSTEP_ACTIVE_RECORD_SPAN_PREFIX | What to prefix the ActiveRecord mysql span with | '' |
+| LIGHTSTEP_REDIS_ALLOW_AS_ROOT_SPAN | Allow redis to be the root span? | 0 |
+| LIGHTSTEP_REDIS_EXCLUDED_COMMANDS | Redis commands to exclude from spans. Comma-separated list. | ping |
 | LIGHTSTEP_VERBOSITY | The verbosity level of lightstep logs. | 1 |
 
 Most systems will only need to customize the component name.
@@ -77,7 +85,7 @@ or systems outside of your instrumenting control.
 
 ### Redis
 
-This gem will automatically detect and instrumnent Redis calls when they are made using the `Redis::Client` class.
+This gem will automatically detect and instrument Redis calls when they are made using the `Redis::Client` class.
 It will set as tags on the span the host, port, db instance, and the command (but no arguments). 
 
 Note that this will not record redis timings if they are a root span. This is to prevent trace spamming. You can 
@@ -85,6 +93,17 @@ re-enable this by setting the `redis_allow_root_spans` configuration option to `
 
 It also excludes `ping` commands, and you can provide a custom list by setting the `redis_excluded_commands` 
 configuration option to an array of commands to exclude.
+
+### ActiveRecord and MySQL
+
+This gem will automatically instrument MySQL queries with spans when made with the `mysql2` gem and ActiveRecord.
+It will set as tags on the span the host, database type, database name, and a sanitized version of the SQL query made.
+The query will have no values - replaced with `?` - to ensure secure logging and no leaking of PII data.
+
+Note that this will not record mysql timings if they are a root span. This is to prevent trace spamming. You can
+configure this gem to allow it via ENV, but it is not recommended.
+
+By default, it will also exclude `COMMIT`, `SCHEMA`, and `SHOW FULL FIELDS` queries. 
 
 ## RSpec
 

--- a/bc-lightstep-ruby.gemspec
+++ b/bc-lightstep-ruby.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.6'
 
+  spec.add_development_dependency 'activerecord', '> 4'
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'bundler-audit', '~> 0.6'
   spec.add_development_dependency 'rake', '>= 12.0'
@@ -45,6 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'null-logger', '~> 0.1'
   spec.add_development_dependency 'redis', '~> 4'
 
+  spec.add_runtime_dependency 'activesupport', '>= 4'
   spec.add_runtime_dependency 'lightstep', '~> 0.13.0'
   spec.add_runtime_dependency 'faraday', ['>= 0.8', '<= 0.15.4']
 end

--- a/lib/bigcommerce/lightstep.rb
+++ b/lib/bigcommerce/lightstep.rb
@@ -17,6 +17,7 @@
 #
 require 'lightstep'
 require 'faraday'
+require 'active_support/concern'
 require_relative 'lightstep/version'
 require_relative 'lightstep/errors'
 require_relative 'lightstep/interceptors/registry'
@@ -27,6 +28,8 @@ require_relative 'lightstep/transport_factory'
 require_relative 'lightstep/transport'
 require_relative 'lightstep/rails_controller_instrumentation'
 require_relative 'lightstep/middleware/faraday'
+require_relative 'lightstep/active_record/tracer'
+require_relative 'lightstep/active_record/adapter'
 require_relative 'lightstep/redis/tracer'
 
 ##
@@ -54,7 +57,10 @@ module Bigcommerce
       ::LightStep.instance.max_log_records = ::Bigcommerce::Lightstep.max_log_records
       ::LightStep.instance.report_period_seconds = ::Bigcommerce::Lightstep.max_reporting_interval_seconds
 
-      ::Bigcommerce::Lightstep::Redis::Wrapper.patch if ::Bigcommerce::Lightstep.enabled
+      return unless ::Bigcommerce::Lightstep.enabled
+
+      ::Bigcommerce::Lightstep::Redis::Wrapper.patch
+      ::Bigcommerce::Lightstep::ActiveRecord::Adapter.patch
     end
   end
 end

--- a/lib/bigcommerce/lightstep/active_record/adapter.rb
+++ b/lib/bigcommerce/lightstep/active_record/adapter.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2020-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Bigcommerce
+  module Lightstep
+    module ActiveRecord
+      ##
+      # Patches mysql and ActiveRecord to allow for mysql span tracing
+      #
+      module Adapter
+        extend ::ActiveSupport::Concern
+
+        ##
+        # Patch ActiveRecord to enable mysql span traces
+        #
+        def self.patch
+          return unless enabled?
+
+          # rubocop:disable Lint/SendWithMixinArgument
+          ::ActiveRecord::ConnectionAdapters::Mysql2Adapter.send(:include, ::Bigcommerce::Lightstep::ActiveRecord::Adapter)
+          # rubocop:enable Lint/SendWithMixinArgument
+        end
+
+        ##
+        # Note: we only support patching mysql2 gem at this point
+        #
+        # @return [Boolean]
+        #
+        def self.enabled?
+          defined?(::ActiveRecord) && ::Bigcommerce::Lightstep.active_record && ::ActiveRecord::Base.connection_config[:adapter].to_s.downcase == 'mysql2'
+        rescue StandardError => e
+          ::Bigcommerce::Lightstep.logger&.warn "Failed to determine ActiveRecord database adapter in bc-lightstep-ruby initializer: #{e.message}"
+          false
+        end
+
+        ##
+        # @param [String] sql The raw sql query
+        # @param [String] name The type of sql query
+        #
+        def execute_with_inst(sql, name = 'SQL')
+          # bail out early if not enabled. This should not get here, but is provided as a failsafe.
+          return execute_without_inst(sql, name) unless ::Bigcommerce::Lightstep.active_record
+
+          sanitized_sql = lightstep_sanitize_sql(sql)
+          name = name.to_s.strip.empty? ? 'QUERY' : name
+
+          # we dont need to track all sql
+          return execute_without_inst(sql, name) if lightstep_skip_tracing?(name, sanitized_sql)
+
+          lightstep_tracer.db_trace(
+            statement: sanitized_sql,
+            host: @config[:host],
+            adapter: @config[:adapter],
+            database: @config[:database]
+          ) do
+            execute_without_inst(sql, name)
+          end
+        end
+
+        ##
+        # Sanitize the sql for safe logging
+        #
+        # @param [String]
+        # @return [String]
+        #
+        def lightstep_sanitize_sql(sql)
+          sql.to_s.gsub(lightstep_sanitization_regexp, '?').tr("\n", ' ').to_s
+        end
+
+        ##
+        # @return [Regexp]
+        #
+        def lightstep_sanitization_regexp
+          @lightstep_sanitization_regexp ||= ::Regexp.new('(\'[\s\S][^\']*\'|\d*\.\d+|\d+|NULL)', ::Regexp::IGNORECASE)
+        end
+
+        ##
+        # Filter out sql queries from tracing we don't care about
+        #
+        # @param [String] name
+        # @param [String] sql
+        # @return [Boolean]
+        def lightstep_skip_tracing?(name, sql)
+          name.empty? || sql.empty? || sql.include?('COMMIT') || sql.include?('SCHEMA') || sql.include?('SHOW FULL FIELDS')
+        end
+
+        ##
+        # @return [::Bigcommerce::Lightstep::ActiveRecord::Tracer]
+        #
+        def lightstep_tracer
+          @lightstep_tracer ||= ::Bigcommerce::Lightstep::ActiveRecord::Tracer.new
+        end
+
+        included do
+          if defined?(::ActiveRecord) && ::ActiveRecord::VERSION::MAJOR > 3
+            alias_method :execute_without_inst, :execute
+            alias_method :execute, :execute_with_inst
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bigcommerce/lightstep/active_record/tracer.rb
+++ b/lib/bigcommerce/lightstep/active_record/tracer.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2020-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+module Bigcommerce
+  module Lightstep
+    module ActiveRecord
+      ##
+      # Tracer adapter for ActiveRecord
+      #
+      class Tracer
+        ##
+        # @param [Bigcommerce::Lightstep::Tracer] tracer
+        # @param [String] span_prefix
+        # @param [Boolean] allow_root_spans
+        # @param [String] span_name
+        #
+        def initialize(tracer: nil, span_prefix: nil, span_name: nil, allow_root_spans: nil)
+          @tracer = tracer || ::Bigcommerce::Lightstep::Tracer.instance
+          @span_prefix = span_prefix || ::Bigcommerce::Lightstep.active_record_span_prefix
+          @span_name = span_name || 'mysql'
+          @allow_root_spans = !allow_root_spans.nil? ? allow_root_spans : ::Bigcommerce::Lightstep.active_record_allow_root_spans
+        end
+
+        ##
+        # Trace a DB call
+        #
+        # @param [String] statement
+        # @param [String] host
+        # @param [String] adapter
+        # @param [String] database
+        #
+        def db_trace(statement:, host:, adapter:, database:)
+          return yield unless @tracer
+
+          # skip if not allowing root spans and there is no active span
+          return yield if !@allow_root_spans && !active_span?
+
+          @tracer.start_span(key) do |span|
+            span.set_tag('db.host', host.to_s)
+            span.set_tag('db.type', adapter.to_s)
+            span.set_tag('db.name', database.to_s)
+            span.set_tag('db.statement', statement.to_s)
+            span.set_tag('span.kind', 'client')
+            begin
+              yield
+            rescue StandardError => _e
+              span.set_tag('error', true)
+              raise # re-raise the error
+            end
+          end
+        end
+
+        ##
+        # @return [String]
+        #
+        def key
+          !@span_prefix.to_s.empty? ? "#{@span_prefix}.mysql" : 'mysql'
+        end
+
+        ##
+        # @return [Boolean]
+        #
+        def active_span?
+          @tracer.respond_to?(:active_span) && @tracer.active_span
+        end
+      end
+    end
+  end
+end

--- a/lib/bigcommerce/lightstep/transport_factory.rb
+++ b/lib/bigcommerce/lightstep/transport_factory.rb
@@ -32,6 +32,10 @@ module Bigcommerce
           encryption: ::Bigcommerce::Lightstep.port.to_i == 443 ? ::Bigcommerce::Lightstep::Transport::ENCRYPTION_TLS : ::Bigcommerce::Lightstep::Transport::ENCRYPTION_NONE,
           ssl_verify_peer: ::Bigcommerce::Lightstep.ssl_verify_peer,
           access_token: ::Bigcommerce::Lightstep.access_token,
+          open_timeout: ::Bigcommerce::Lightstep.open_timeout,
+          read_timeout: ::Bigcommerce::Lightstep.read_timeout,
+          continue_timeout: ::Bigcommerce::Lightstep.continue_timeout,
+          keep_alive_timeout: ::Bigcommerce::Lightstep.keep_alive_timeout,
           logger: ::Bigcommerce::Lightstep.logger
         )
       end

--- a/lib/bigcommerce/lightstep/version.rb
+++ b/lib/bigcommerce/lightstep/version.rb
@@ -17,6 +17,6 @@
 #
 module Bigcommerce
   module Lightstep
-    VERSION = '2.0.1.pre'
+    VERSION = '2.1.0.pre'
   end
 end

--- a/spec/bigcommerce/lightstep/active_record/tracer_spec.rb
+++ b/spec/bigcommerce/lightstep/active_record/tracer_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+# Copyright (c) 2020-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+class TestActiveRecordTracerCaller
+  def foo
+    true
+  end
+end
+
+describe Bigcommerce::Lightstep::ActiveRecord::Tracer do
+  let(:allow_root_spans) { false }
+  let(:span_prefix) { 'auth' }
+  let(:span_name) { 'mysql' }
+  let(:tracer) { described_class.new(tracer: mock_tracer, allow_root_spans: allow_root_spans, span_prefix: span_prefix, span_name: span_name) }
+
+  describe '.db_trace' do
+    let(:statement) { 'SELECT * FROM accounts WHERE username = ?' }
+    let(:adapter) { 'mysql' }
+    let(:host) { 'redis.service' }
+    let(:database) { 'test_dev' }
+    let(:key) { "#{span_prefix}.#{span_name}" }
+    let(:caller) { TestActiveRecordTracerCaller.new }
+
+    subject do
+      tracer.db_trace(statement: statement, adapter: adapter, host: host, database: database) do
+        caller.foo
+      end
+    end
+
+    context 'if the trace is successful' do
+      it 'should trace the result' do
+        expect(mock_tracer).to receive(:start_span).with(key).and_call_original
+        expect(mock_tracer.span).to receive(:set_tag).with('db.host', host).ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('db.type', adapter).ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('db.name', database).ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('db.statement', statement).ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('span.kind', 'client').ordered
+
+        expect(caller).to receive(:foo).once
+
+        subject
+      end
+
+      context 'if allowing root spans is disabled' do
+        let(:allow_root_spans) { false }
+
+        context 'and there is no active span' do
+          before do
+            allow(mock_tracer).to receive(:active_span).and_return(nil)
+          end
+
+          it 'should not trace the result' do
+            expect(mock_tracer).to_not receive(:start_span)
+            expect(caller).to receive(:foo).once
+            subject
+          end
+        end
+
+        context 'and there is a root span' do
+          it 'should trace the result' do
+            expect(mock_tracer).to receive(:start_span).and_call_original
+            expect(caller).to receive(:foo).once
+            subject
+          end
+        end
+      end
+
+      context 'if allowing root spans is enabled' do
+        let(:allow_root_spans) { true }
+
+        context 'and there is no active span' do
+          before do
+            allow(mock_tracer).to receive(:active_span).and_return(nil)
+          end
+
+          it 'should trace the result' do
+            expect(mock_tracer).to receive(:start_span).and_call_original
+            expect(caller).to receive(:foo).once
+            subject
+          end
+        end
+
+        context 'and there is a root span' do
+          it 'should trace the result' do
+            expect(mock_tracer).to receive(:start_span).and_call_original
+            expect(caller).to receive(:foo).once
+            subject
+          end
+        end
+      end
+    end
+
+    context 'if the trace raises an exception' do
+      let(:exception) { StandardError.new('Oh noes') }
+
+      before do
+        allow(caller).to receive(:foo).and_raise(exception)
+      end
+
+      it 'should trace the result and add an error tag to the span' do
+        expect(mock_tracer).to receive(:start_span).with(key).and_call_original
+        expect(mock_tracer.span).to receive(:set_tag).with('db.host', host).ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('db.type', adapter).ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('db.name', database).ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('db.statement', statement).ordered
+        expect(mock_tracer.span).to receive(:set_tag).with('span.kind', 'client').ordered
+
+        expect(mock_tracer.span).to receive(:set_tag).with('error', true).ordered
+
+        expect(caller).to receive(:foo).once
+
+        expect { subject }.to raise_error(exception)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What?

* Adds automatic mysql span tracing for ActiveRecord
* Adds missing ENV vars for configuration of various other elements
* Clarify explicit dependency on active_support
* More clearly documents README for above

----

@bigcommerce/ruby @bigcommerce/platform-engineering @jmwiese 