### PR TITLE
Only set error tag if not already set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the bc-lightstep-ruby gem.
 
 ### Pending Release
 
+- Only set error tag in exceptions if not already set
+
 ### 2.1.1
 
 - Bump lightstep gem to 0.16.0


### PR DESCRIPTION
Related to https://github.com/bigcommerce/gruf-lightstep/pull/15 - The current error tag addition when rescuing StandardError in the tracer prevents upstream libraries from handling errors their own way. This causes issues when wanting to conditionally flag different types of exceptions as errors (say, GRPC status codes). This fixes this by only setting the error tag if it is not already set.

---

@bigcommerce/platform-engineering @bigcommerce/ruby 