### PR TITLE
Fix issue where parent span determination can be nil if lightstep is not initialized

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 ruby_env: &ruby_env
   working_directory: ~/repo
   environment:
+    BUNDLE_GEMFILE: Gemfile
     BUNDLE_JOBS: 4
     BUNDLE_RETRY: 3
     BUNDLE_PATH: vendor/bundle
@@ -18,7 +19,13 @@ executors:
     parameters:
       ruby-version:
         type: string
-        default: "2.6.5"
+        default: "2.6"
+  ruby_2_7:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "2.7"
 
 commands:
   pre-setup:
@@ -26,15 +33,24 @@ commands:
       - add_ssh_keys
       - checkout
   bundle-install:
+    parameters:
+      checksumfile:
+        type: string
+        default: "Gemfile.lock"
+      cache_key:
+        type: string
+        default: "gem-cache-2"
     steps:
       - restore_cache:
           keys:
-            - gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - gem-cache-{{ arch }}-{{ .Branch }}
-            - gem-cache
-      - run: bundle check || bundle install --path vendor/bundle
+            - <<parameters.cache_key>>-{{ arch }}-{{ .Branch }}-{{ checksum "<<parameters.checksumfile>>" }}
+            - <<parameters.cache_key>>-{{ arch }}-{{ .Branch }}
+            - <<parameters.cache_key>>
+      - run: |
+          bundle check --path vendor/bundle || bundle install --path vendor/bundle
+          bundle clean
       - save_cache:
-          key: gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: <<parameters.cache_key>>-{{ arch }}-{{ .Branch }}-{{ checksum "<<parameters.checksumfile>>" }}
           paths:
             - vendor/bundle
   rspec-unit:
@@ -113,3 +129,14 @@ workflows:
       - rspec-unit:
           name: "ruby-2_6-rspec"
           e: "ruby_2_6"
+  ruby_2_7:
+    jobs:
+      - bundle-audit:
+          name: "ruby-2_7-bundle_audit"
+          e: "ruby_2_7"
+      - rubocop:
+          name: "ruby-2_7-rubocop"
+          e: "ruby_2_7"
+      - rspec-unit:
+          name: "ruby-2_7-rspec"
+          e: "ruby_2_7"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the bc-lightstep-ruby gem.
 
 ### Pending Release
 
+- Fix issue where parent span determination can be nil if lightstep is not initialized
+
 ### 2.2.1
 
 - Only set error tag in exceptions if not already set

--- a/bc-lightstep-ruby.gemspec
+++ b/bc-lightstep-ruby.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6'
 
   spec.add_development_dependency 'activerecord', '> 4'
-  spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'bundler-audit', '~> 0.6'
   spec.add_development_dependency 'rake', '>= 12.0'
   spec.add_development_dependency 'rspec', '~> 3.8'

--- a/spec/bigcommerce/lightstep/tracer_spec.rb
+++ b/spec/bigcommerce/lightstep/tracer_spec.rb
@@ -1,0 +1,67 @@
+# Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+describe Bigcommerce::Lightstep::Tracer do
+  let(:tracer) { described_class.instance }
+
+  describe '#start_span' do
+    subject {  }
+
+    let(:operation_name) { 'test' }
+
+    it 'yields a span' do
+      tracer.start_span(operation_name) do |span|
+        expect(span).to be_a(LightStep::Span)
+      end
+    end
+
+    it 'sets the current span as the active span' do
+      tracer.start_span('outer') do |outer_span|
+        expect(outer_span).to be_a(LightStep::Span)
+        expect(tracer.active_span).to eq outer_span
+        expect(Thread.current[:lightstep_active_span]).to eq outer_span
+
+        tracer.start_span('inner') do |inner_span|
+          expect(inner_span).to be_a(LightStep::Span)
+          expect(tracer.active_span).to eq inner_span
+          expect(Thread.current[:lightstep_active_span]).to eq inner_span
+        end
+      end
+    end
+
+    it 'sets the outer span as the root span' do
+      tracer.start_span('outer') do |outer_span|
+        expect(outer_span.instance_variable_get(:@root_span)).to be_truthy
+        tracer.start_span('inner') do |inner_span|
+          expect(inner_span.instance_variable_get(:@root_span)).to be_falsey
+        end
+      end
+    end
+
+    context 'when the LightStep reporter is not initialized' do
+      it 'returns a span regardless' do
+        expect(LightStep.instance.instance_variable_get(:@reporter)).to be_nil
+
+        expect do
+          tracer.start_span(operation_name) do |span|
+            expect(span).to be_a(LightStep::Span)
+          end
+        end.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes some of the issues where we've seen in LightStep's 0.16 release: 

``` 
undefined method `extract' for nil:NilClass\n/opt/ruby2.6/lib/ruby/gems/2.6.0/gems/lightstep-0.16.0/lib/lightstep/tracer.rb:210
```

by adding sufficient guards when LightStep is not initialized, but start_span has been called.

---

@bigcommerce/ruby 