### PR TITLE
Relax pin on faraday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for the bc-lightstep-ruby gem.
 
 ### Pending Release
 
+### 2.3.1
+
+- Loosen faraday dependency
+
 ### 2.3.0
 
 - Add support for Ruby 3

--- a/bc-lightstep-ruby.gemspec
+++ b/bc-lightstep-ruby.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activesupport', '>= 4'
   spec.add_runtime_dependency 'lightstep', '~> 0.17.0'
-  spec.add_runtime_dependency 'faraday', ['>= 0.8', '<= 0.17.3']
+  spec.add_runtime_dependency 'faraday', ['>= 0.8', '< 2']
 end


### PR DESCRIPTION
## What?

This allows other apps a more seamless transition to update Faraday. This library only uses Faraday for middleware support, which transitive dependencies should handle fine.

---

@bigcommerce/ruby @bigcommerce/oss-maintainers 