### PR TITLE
Add `::Bigcommerce::Lightstep::Traceable` module for tracing individual methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog for the bc-lightstep-ruby gem.
 
 ### Pending Release
 
+* Add `::Bigcommerce::Lightstep::Traceable` module for tracing individual methods
 * Use zeitwerk for autoloading
 * Add CODEOWNERS and GitHub PR Template
 * Add Ruby 3.1 support

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/bigcommerce/bc-lightstep-ruby/tree/main.svg?style=svg)](https://circleci.com/gh/bigcommerce/bc-lightstep-ruby/tree/main) [![Gem Version](https://badge.fury.io/rb/bc-lightstep-ruby.svg)](https://badge.fury.io/rb/bc-lightstep-ruby) [![Inline docs](http://inch-ci.org/github/bigcommerce/bc-lightstep-ruby.svg?branch=main)](http://inch-ci.org/github/bigcommerce/bc-lightstep-ruby) [![Maintainability](https://api.codeclimate.com/v1/badges/72191c29a56368431942/maintainability)](https://codeclimate.com/github/bigcommerce/bc-lightstep-ruby/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/72191c29a56368431942/test_coverage)](https://codeclimate.com/github/bigcommerce/bc-lightstep-ruby/test_coverage)
 
-Adds [LightStep](https://lightstep.com) tracing support for Ruby. This is an extension of the 
+Adds [LightStep](https://lightstep.com) tracing support for Ruby. This is an extension of the
 [LightStep ruby gem](https://github.com/lightstep/lightstep-tracer-ruby) and adds extra functionality and resiliency.
 
 ## Installation
@@ -41,8 +41,8 @@ bc-lightstep-ruby can be automatically configured from these ENV vars, if you'd 
 | Name | Description |
 | ---- | ----------- |
 | LIGHTSTEP_ENABLED | Flag to determine whether to broadcast spans. Defaults to (1) enabled, 0 will disable.| 1 |
-| LIGHTSTEP_COMPONENT_NAME | The component name to use | '' | 
-| LIGHTSTEP_ACCESS_TOKEN | The access token to use to connect to the collector. Optional. | '' | 
+| LIGHTSTEP_COMPONENT_NAME | The component name to use | '' |
+| LIGHTSTEP_ACCESS_TOKEN | The access token to use to connect to the collector. Optional. | '' |
 | LIGHTSTEP_HOST | Host of the collector. | `lightstep-collector.linkerd` |
 | LIGHTSTEP_PORT | Port of the collector. | `4140` |
 | LIGHTSTEP_HTTP1_ERROR_CODE | The HTTP error code to report in spans for internal errors | 500 |
@@ -86,12 +86,12 @@ or systems outside of your instrumenting control.
 ### Redis
 
 This gem will automatically detect and instrument Redis calls when they are made using the `Redis::Client` class.
-It will set as tags on the span the host, port, db instance, and the command (but no arguments). 
+It will set as tags on the span the host, port, db instance, and the command (but no arguments).
 
-Note that this will not record redis timings if they are a root span. This is to prevent trace spamming. You can 
+Note that this will not record redis timings if they are a root span. This is to prevent trace spamming. You can
 re-enable this by setting the `redis_allow_root_spans` configuration option to `true`.
 
-It also excludes `ping` commands, and you can provide a custom list by setting the `redis_excluded_commands` 
+It also excludes `ping` commands, and you can provide a custom list by setting the `redis_excluded_commands`
 configuration option to an array of commands to exclude.
 
 ### ActiveRecord and MySQL
@@ -103,7 +103,27 @@ The query will have no values - replaced with `?` - to ensure secure logging and
 Note that this will not record mysql timings if they are a root span. This is to prevent trace spamming. You can
 configure this gem to allow it via ENV, but it is not recommended.
 
-By default, it will also exclude `COMMIT`, `SCHEMA`, and `SHOW FULL FIELDS` queries. 
+By default, it will also exclude `COMMIT`, `SCHEMA`, and `SHOW FULL FIELDS` queries.
+
+### Individual methods
+
+You can easily instrument individual methods with the Traceable module and `trace` method:
+
+```ruby
+class MyService
+  include ::Bigcommerce::Lightstep::Traceable
+
+  trace :call, 'operation.do-my-thing' do |span:, product:, options:|
+    span.set_tag('store_id', request.store_id)
+  end
+  # or, with no block:
+  trace :call, 'operation.do-my-thing'
+
+  def call(product:, options:)
+    # ...
+  end
+end
+```
 
 ## RSpec
 
@@ -130,7 +150,7 @@ dynamically inject tags or alter spans as they are collected. You can configure 
 Bigcommerce::Lightstep.configure do |c|
   c.interceptors.use(MyInterceptor, an_option: 123)
   # or, alternatively:
-  c.interceptors.use(MyInterceptor.new(an_option: 123)) 
+  c.interceptors.use(MyInterceptor.new(an_option: 123))
 end
 ```
 
@@ -156,21 +176,21 @@ The `keys` argument allows you to pass a `span tag => ENV key` mapping that will
 `presets` argument comes with a bunch of preset mappings you can use rather than manually mapping them yourself.
 
 Note that this interceptor _must_ be instantiated in configuration, rather than passing the class and options,
-as it needs to pre-materialize the ENV values to reduce CPU usage. 
+as it needs to pre-materialize the ENV values to reduce CPU usage.
 
 ## License
 
-Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved 
+Copyright (c) 2018-present, BigCommerce Pty. Ltd. All rights reserved
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
-documentation files (the "Software"), to deal in the Software without restriction, including without limitation the 
-rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
 persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the 
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
 Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE 
-WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR 
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/lib/bigcommerce/lightstep/traceable.rb
+++ b/lib/bigcommerce/lightstep/traceable.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Bigcommerce
+  module Lightstep
+    ##
+    # Module for adding drop-in tracing to any method. Example usage:
+    #
+    # ```ruby
+    # class MyService
+    #   include ::Bigcommerce::Lightstep::Traceable
+    #
+    #   trace :call, 'operation.do-my-thing' do |span, product, options|
+    #     span.set_tag('store_id', request.store_id)
+    #   end
+    #   # or, with no block:
+    #   trace :call, 'operation.do-my-thing'
+    #
+    #   def call(product:, options:)
+    #     # ...
+    #   end
+    # end
+    # ```
+    #
+    module Traceable
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      ##
+      # Extend the class with the tracing methods.
+      #
+      module ClassMethods
+        ##
+        # Trace the perform method for the command with the given operation name as the span name
+        #
+        # @param [Symbol] method_name The method to trace
+        # @param [String] operation_name The name to give the span
+        # @param [Hash] tags A key/value hash of tags to set on the created span
+        # @param [Proc] span_block A block to yield before calling perform; useful for setting tags on the outer span
+        #
+        def trace(method_name, operation_name, tags: nil, &span_block)
+          method_name = method_name.to_sym
+          mod = Module.new
+          mod.define_method(method_name) do |args, &block|
+            tracer = ::Bigcommerce::Lightstep::Tracer.instance
+            tracer.start_span(operation_name) do |span|
+              tags&.each { |k, v| span.set_tag(k.to_s, v) }
+              span_block&.send(:call, **args.merge(span: span))
+              begin
+                super(**args, &block)
+              rescue StandardError => e
+                span.set_tag('error', true)
+                span.set_tag('error.message', e.message)
+                span.set_tag('error.class', e.class.to_s)
+                raise
+              end
+            end
+          end
+          prepend(mod)
+        end
+      end
+    end
+  end
+end

--- a/lib/bigcommerce/lightstep/version.rb
+++ b/lib/bigcommerce/lightstep/version.rb
@@ -17,6 +17,6 @@
 #
 module Bigcommerce
   module Lightstep
-    VERSION = '2.3.2.pre'
+    VERSION = '2.4.0.pre'
   end
 end

--- a/spec/bigcommerce/lightstep/traceable_spec.rb
+++ b/spec/bigcommerce/lightstep/traceable_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Bigcommerce::Lightstep::Traceable do
+  let(:service) { TestTracedService.new }
+  let(:method_name) { :call }
+  let(:lightstep) { ::Bigcommerce::Lightstep::Tracer.instance }
+  let(:span) { instance_double(::LightStep::Span, set_tag: true) }
+
+  before do
+    allow(lightstep).to receive(:start_span).and_yield(span)
+  end
+
+  describe '#trace' do
+    subject { service.call(name: name, should_fail: should_fail) }
+
+    let(:name) { 'foo' }
+    let(:should_fail) { false }
+
+    it 'calls and passes the args to the trace block' do
+      expect(span).to receive(:set_tag).with('name', name)
+      subject
+    end
+
+    it 'still calls the traced method' do
+      expect(subject).to eq name
+    end
+
+    it 'sets the span with the passed operation name' do
+      expect(lightstep).to receive(:start_span).with('operation.call').and_yield(span)
+      expect(subject).to eq name
+    end
+
+    context 'when no block is passed to trace' do
+      subject { service.call_without_block(name: name, should_fail: should_fail) }
+
+      it 'the perform method calls normally' do
+        expect(span).not_to receive(:set_tag).with('traced', true)
+        expect(subject).to eq name
+      end
+    end
+
+    context 'when the command fails' do
+      let(:should_fail) { true }
+
+      it 'raises it normally and tags the span with the error' do
+        expect(span).to receive(:set_tag).with('error', true)
+        expect(span).to receive(:set_tag).with('error.message', 'oops')
+        expect(span).to receive(:set_tag).with('error.class', 'StandardError')
+        expect { subject }.to raise_error(StandardError, 'oops')
+      end
+    end
+
+    context 'when tags are passed to trace' do
+      subject { service.call_with_tags(name: name) }
+
+      it 'sets them on the span' do
+        expect(span).to receive(:set_tag).with('foo', 'bar').ordered
+        expect(span).to receive(:set_tag).with('name', name).ordered
+        expect(subject).to eq name
+      end
+    end
+  end
+end

--- a/spec/support/traceable.rb
+++ b/spec/support/traceable.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class TestTracedService
+  include ::Bigcommerce::Lightstep::Traceable
+
+  trace :call, 'operation.call' do |span:, name:, should_fail:|
+    span.set_tag('traced', true)
+    span.set_tag('name', name)
+  end
+  def call(name:, should_fail:)
+    raise StandardError, 'oops' if should_fail
+
+    name
+  end
+
+  trace :call_without_block, 'operation.call_without_block'
+  def call_without_block(name:, should_fail:)
+    raise StandardError, 'oops' if should_fail
+
+    name
+  end
+
+  trace :call_with_tags, 'operation.call_with_tags', tags: { foo: 'bar' } do |span:, name:|
+    span.set_tag('name', name)
+  end
+  def call_with_tags(name:)
+    name
+  end
+end


### PR DESCRIPTION
## What/Why?

Adds the ability to add a span to any method via a Traceable module and `trace` class method:

```ruby
class MyService
  include ::Bigcommerce::Lightstep::Traceable

  trace :call, 'operation.do-my-thing' do |span:, product:, options:|
    span.set_tag('store_id', request.store_id)
  end
  # or, with no block:
  trace :call, 'operation.do-my-thing'

  def call(product:, options:)
    # ...
  end
end
```

