### PR TITLE
Support positional argument methods when using the `Traceable` trace method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the bc-lightstep-ruby gem.
 
 ### Pending Release
 
+* Support positional argument methods when using the `Traceable` trace method
+
 ### 2.4.0
 
 * Add `::Bigcommerce::Lightstep::Traceable` module for tracing individual methods

--- a/spec/bigcommerce/lightstep/traceable_spec.rb
+++ b/spec/bigcommerce/lightstep/traceable_spec.rb
@@ -61,5 +61,41 @@ describe Bigcommerce::Lightstep::Traceable do
         expect(subject).to eq name
       end
     end
+
+    context 'with a positional arguments method' do
+      subject { service.call_with_positional_args('foo', 'bar') }
+
+      it 'passes correctly to the span block and the method' do
+        expect(span).to receive(:set_tag).with('one', 'foo').ordered
+        expect(span).to receive(:set_tag).with('two', 'bar').ordered
+        expect(span).to receive(:set_tag).with('three', nil).ordered
+        expect(subject).to eq %w[foo bar baz]
+      end
+
+      context 'with a single hash argument' do
+        subject { service.call_with_single_hash_arg(my_hash) }
+
+        let(:my_hash) { { one: 'foo', two: 'bar' } }
+
+        it 'sets them on the span, but merges in the span to the passed hash' do
+          expect(span).to receive(:set_tag).with('one', 'foo').ordered
+          expect(span).to receive(:set_tag).with('two', 'bar').ordered
+          expect(subject).to eq my_hash
+        end
+      end
+
+      context 'with multiple hash arguments' do
+        subject { service.call_with_multiple_hash_args(hash_1, hash_2) }
+
+        let(:hash_1) { { one: 'foo' } }
+        let(:hash_2) { { two: 'bar' } }
+
+        it 'passes them as positional arguments to the trace block' do
+          expect(span).to receive(:set_tag).with('one', 'foo').ordered
+          expect(span).to receive(:set_tag).with('two', 'bar').ordered
+          expect(subject).to eq [hash_1, hash_2]
+        end
+      end
+    end
   end
 end

--- a/spec/support/traceable.rb
+++ b/spec/support/traceable.rb
@@ -26,4 +26,29 @@ class TestTracedService
   def call_with_tags(name:)
     name
   end
+
+  trace :call_with_single_hash_arg, 'operation.call_with_single_hash_arg' do |my_hash|
+    my_hash[:span].set_tag('one', my_hash[:one])
+    my_hash[:span].set_tag('two', my_hash[:two])
+  end
+  def call_with_single_hash_arg(my_hash)
+    my_hash
+  end
+
+  trace :call_with_multiple_hash_args, 'operation.call_with_single_hash_arg' do |span, hash_1, hash_2|
+    span.set_tag('one', hash_1[:one])
+    span.set_tag('two', hash_2[:two])
+  end
+  def call_with_multiple_hash_args(hash_1, hash_2)
+    [hash_1, hash_2]
+  end
+
+  trace :call_with_positional_args, 'operation.call_with_positional_args' do |span, one, two, three|
+    span.set_tag('one', one)
+    span.set_tag('two', two)
+    span.set_tag('three', three)
+  end
+  def call_with_positional_args(one, two, three = 'baz')
+    [one, two, three]
+  end
 end


### PR DESCRIPTION
## What/Why?

The trace method introduced in #36 does not support tracing positional argument methods. This adds support for it, with a slight caveat around single-hash-argument positional methods.

## Testing

rspec, manually
