### PR TITLE
Add support for ActiveRecord 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog for the bc-lightstep-ruby gem.
 
 ### Pending Release
 
+* Add support for Rails/ActiveRecord 7
 * Add test coverage for Ruby 3.2
 
 ### 2.5.x


### PR DESCRIPTION
## What/Why?

Handle the new ActiveRecord interfaces in Rails 7 with the ActiveRecord instrumentor.

## Testing

Put this on a Rails 7 repository, works as expected:

```
# HELP active_record_connection_pool_connections Total connections in pool
# TYPE active_record_connection_pool_connections gauge
active_record_connection_pool_connections{pool_name="primary",pid="79850"} 0

# HELP active_record_connection_pool_busy Connections in use in pool
# TYPE active_record_connection_pool_busy gauge
active_record_connection_pool_busy{pool_name="primary",pid="79850"} 0

# HELP active_record_connection_pool_dead Dead connections in pool
# TYPE active_record_connection_pool_dead gauge
active_record_connection_pool_dead{pool_name="primary",pid="79850"} 0

# HELP active_record_connection_pool_idle Idle connections in pool
# TYPE active_record_connection_pool_idle gauge
active_record_connection_pool_idle{pool_name="primary",pid="79850"} 0

# HELP active_record_connection_pool_waiting Connection requests waiting
# TYPE active_record_connection_pool_waiting gauge
active_record_connection_pool_waiting{pool_name="primary",pid="79850"} 0

# HELP active_record_connection_pool_size Maximum allowed connection pool size
# TYPE active_record_connection_pool_size gauge
active_record_connection_pool_size{pool_name="primary",pid="79850"} 16
```