### PR TITLE
Loosen Faraday dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the bc-lightstep-ruby gem.
 
 ### Pending Release
 
+* Loosen faraday dependency
+
 ### 2.6.0
 
 * Add support for Rails/ActiveRecord 7

--- a/bc-lightstep-ruby.gemspec
+++ b/bc-lightstep-ruby.gemspec
@@ -47,6 +47,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activesupport', '>= 4'
   spec.add_runtime_dependency 'lightstep', '~> 0.17.0'
-  spec.add_runtime_dependency 'faraday', ['>= 0.8', '< 2']
+  spec.add_runtime_dependency 'faraday', ['>= 0.8', '<= 2.7.11']
   spec.add_runtime_dependency 'zeitwerk', '>= 2'
 end


### PR DESCRIPTION
## What/Why?


Reading through the Faraday [upgrade guide](https://github.com/lostisland/faraday/blob/main/UPGRADING.md#faraday-20), our LightStep middleware should be compatible with Faraday v2. This PR loosens the Faraday dependency to include v2.

## Testing

Including this PR in A&A and testing if the middleware still works as expected. Adding screenshots for POL
