### PR TITLE
Provide a hook for controllers to pass additional span tags

### DIFF
--- a/lib/bigcommerce/lightstep/rails_controller_instrumentation.rb
+++ b/lib/bigcommerce/lightstep/rails_controller_instrumentation.rb
@@ -30,6 +30,10 @@ module Bigcommerce
           span.set_tag('http.content_type', request.format)
           span.set_tag('http.host', request.host)
           span.set_tag('span.kind', 'server')
+
+          # provide a hook for controllers to provide additional span tags
+          lightstep_additional_span_tags.each { |tag_name, value| span.set_tag(tag_name.to_s, value.to_s) }
+
           begin
             resp = yield
           rescue StandardError => _e
@@ -46,6 +50,15 @@ module Bigcommerce
         end
         tracer.clear_active_span!
         result
+      end
+
+      ##
+      # Get list of additional span tags
+      #
+      # @return [Hash]
+      #
+      def lightstep_additional_span_tags
+        {}
       end
 
       ##


### PR DESCRIPTION
## What/Why?

Provide a hook for controllers to specify additional span tags.

## Testing

Tested it on a controller which uses the instrumentation trace
```ruby
def lightstep_additional_span_tags
   {
       store_id: params[:store_id]
   }
end
```
<img width="400" alt="image" src="https://github.com/bigcommerce/bc-lightstep-ruby/assets/1313863/4c8de0d0-d42a-41c1-ade6-9f04152ea810">
