### PR TITLE
2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for the bc-lightstep-ruby gem.
 
 ### Pending Release
 
+### 2.6.1
+
+* Supports hook for controllers to specify additional span tags
+
 ### 2.6.0
 
 * Add support for Rails/ActiveRecord 7

--- a/lib/bigcommerce/lightstep/version.rb
+++ b/lib/bigcommerce/lightstep/version.rb
@@ -17,6 +17,6 @@
 #
 module Bigcommerce
   module Lightstep
-    VERSION = '2.6.1.pre'
+    VERSION = '2.6.1'
   end
 end


### PR DESCRIPTION
## What/Why?

Bump version as per the [documentation](https://bc-eng-docs.herokuapp.com/technical/languages/ruby/gems/release_process.html)

Direct push to main failed so creating a PR

```
git push
Enumerating objects: 13, done.
Counting objects: 100% (13/13), done.
Delta compression using up to 10 threads
Compressing objects: 100% (6/6), done.
Writing objects: 100% (7/7), 617 bytes | 617.00 KiB/s, done.
Total 7 (delta 4), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: error: Changes must be made through a pull request. 6 of 6 required status checks are expected.
To github.com:bigcommerce/bc-lightstep-ruby.git
 ! [remote rejected] main -> main (protected branch hook declined)
```

## Testing
- skipping this section as this is just a bump
