### PR TITLE
Do not instrument redis 5.x in this library for compatibility reasons

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,12 @@ ruby_3_2_defaults: &ruby_3_2_defaults
     name: ruby/ruby
     ruby-version: '3.2'
 
+ruby_3_3_defaults: &ruby_3_3_defaults
+  <<: *defaults
+  e:
+    name: ruby/ruby
+    ruby-version: '3.3'
+
 workflows:
   version: 2
   ruby_3_0:
@@ -63,5 +69,18 @@ workflows:
       - ruby/rspec-unit:
           <<: *ruby_3_2_defaults
           name: ruby-3_2-rspec_unit
+          db: false
+          code-climate: false
+  ruby_3_3:
+    jobs:
+      - ruby/bundle-audit:
+          <<: *ruby_3_3_defaults
+          name: ruby-3_3-bundle_audit
+      - ruby/rubocop:
+          <<: *ruby_3_3_defaults
+          name: ruby-3_3-rubocop
+      - ruby/rspec-unit:
+          <<: *ruby_3_3_defaults
+          name: ruby-3_3-rspec_unit
           db: false
           code-climate: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the bc-lightstep-ruby gem.
 
 ### Pending Release
 
+* Do not instrument redis 5.x in this library for compatibility reasons; instead encourage moving away from
+  this library and to OTel gems instead
+
 ### 2.6.1
 
 * Supports hook for controllers to specify additional span tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog for the bc-lightstep-ruby gem.
 
 * Do not instrument redis 5.x in this library for compatibility reasons; instead encourage moving away from
   this library and to OTel gems instead
+* Add CI suite for Ruby 3.3
 
 ### 2.6.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,15 @@
 #
 source 'https://rubygems.org'
 
+gem 'activerecord', '> 4'
+gem 'bundler-audit', '~> 0.6'
+gem 'pry', '>= 0.12'
+gem 'rake', '>= 12.0'
+gem 'redis', ENV.fetch('REDIS_GEM_PIN', '~> 5').to_s
+gem 'rspec', '>= 3.8'
+gem 'rspec_junit_formatter', '~> 0.4'
+gem 'rubocop', '>= 1.0'
+gem 'rubocop-performance', '>= 1.5'
+gem 'simplecov', '~> 0.15'
+
 gemspec

--- a/bc-lightstep-ruby.gemspec
+++ b/bc-lightstep-ruby.gemspec
@@ -34,17 +34,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.0'
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.add_development_dependency 'activerecord', '> 4'
-  spec.add_development_dependency 'bundler-audit', '~> 0.6'
-  spec.add_development_dependency 'rake', '>= 12.0'
-  spec.add_development_dependency 'redis', '~> 4'
-  spec.add_development_dependency 'rspec', '>= 3.8'
-  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
-  spec.add_development_dependency 'rubocop', '>= 1.0'
-  spec.add_development_dependency 'rubocop-performance', '>= 1.5'
-  spec.add_development_dependency 'simplecov', '~> 0.15'
-  spec.add_development_dependency 'pry', '>= 0.12'
-
   spec.add_runtime_dependency 'activesupport', '>= 4'
   spec.add_runtime_dependency 'lightstep', '~> 0.17.0'
   spec.add_runtime_dependency 'faraday', ['>= 0.8', '< 2']

--- a/lib/bigcommerce/lightstep/configuration.rb
+++ b/lib/bigcommerce/lightstep/configuration.rb
@@ -95,7 +95,7 @@ module Bigcommerce
       #
       def reset
         VALID_CONFIG_KEYS.each do |k, v|
-          send("#{k}=".to_sym, v)
+          send(:"#{k}=", v)
         end
 
         default_logger = ::Logger.new($stdout)

--- a/lib/bigcommerce/lightstep/redis/wrapper.rb
+++ b/lib/bigcommerce/lightstep/redis/wrapper.rb
@@ -25,6 +25,10 @@ module Bigcommerce
         class << self
           def patch
             require 'redis' # thread and fork safety
+
+            # do not patch Redis 5.0.0 or later, move to OpenTelemetry gems instead
+            return false unless defined?(::Redis) && ::Redis::VERSION < '5'
+
             return if @wrapped
 
             wrap unless @wrapped


### PR DESCRIPTION
## What/Why?

This gem does not support Redis 5.x; drop support for it and encourage moving to the OpenTelemetry provided ruby libraries over this gem.

Also add Ruby 3.3 test suite.

## Testing

`bundle exec rspec`, as well as this PR.