### PR TITLE
ENGP-245: Update PR template to standard tpl

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,27 @@
-## What/Why?
+Jira: [JIRA_TOKEN](https://bigcommercecloud.atlassian.net/browse/JIRA_TOKEN)
 
+## What/Why?
 <!---
   A description about what this pull request implements and its purpose.
   Try to be detailed and describe any technical details to simplify the job
   of the reviewer and the individual on production support.
 --->
 
-## Testing
+## Rollout/Rollback
+<!--
+Detail how this change will be rolled out. Include reference to any
+experiments and how the success will be measured as the experiment is
+ramped.
 
+Document rollback procedures. Is rolling back the change as simple as
+rolling back an experiment or does it require reverting code? Are there
+database migrations that may change our decision to roll forward instead of
+back?
+-->
+
+## Testing
 <!---
-  Provide as much information as you can about how you tested and
-  how another developer can test.
+Provide as much information as you can about how you tested and how another
+Engineer can test your change. Include screenshots, or test run output
+where appropriate.
 --->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-Jira: [JIRA_TOKEN](https://bigcommercecloud.atlassian.net/browse/JIRA_TOKEN)
-
 ## What/Why?
 <!---
   A description about what this pull request implements and its purpose.


### PR DESCRIPTION
## What/Why?

Updates PR template to standard template. See https://docs.dev.bigcommerce.net/process/repositories/pull-request-templates.html

## Rollout/Rollback

Revert this PR.

## Testing

This PR tests it, essentially.


[ENGP-245]: https://bigcommercecloud.atlassian.net/browse/ENGP-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ