### PR TITLE
Add Ruby 3.4 support, drop Ruby 3.0, 3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,18 +7,6 @@ orbs:
 defaults: &defaults
   notify_failure: false
 
-ruby_3_0_defaults: &ruby_3_0_defaults
-  <<: *defaults
-  e:
-    name: ruby/ruby
-    ruby-version: '3.0'
-
-ruby_3_1_defaults: &ruby_3_1_defaults
-  <<: *defaults
-  e:
-    name: ruby/ruby
-    ruby-version: '3.1'
-
 ruby_3_2_defaults: &ruby_3_2_defaults
   <<: *defaults
   e:
@@ -31,33 +19,14 @@ ruby_3_3_defaults: &ruby_3_3_defaults
     name: ruby/ruby
     ruby-version: '3.3'
 
+ruby_3_4_defaults: &ruby_3_4_defaults
+  <<: *defaults
+  e:
+    name: ruby/ruby
+    ruby-version: '3.4'
+
 workflows:
   version: 2
-  ruby_3_0:
-    jobs:
-      - ruby/bundle-audit:
-          <<: *ruby_3_0_defaults
-          name: ruby-3_0-bundle_audit
-      - ruby/rubocop:
-          <<: *ruby_3_0_defaults
-          name: ruby-3_0-rubocop
-      - ruby/rspec-unit:
-          <<: *ruby_3_0_defaults
-          name: ruby-3_0-rspec_unit
-          db: false
-  ruby_3_1:
-    jobs:
-      - ruby/bundle-audit:
-          <<: *ruby_3_1_defaults
-          name: ruby-3_1-bundle_audit
-      - ruby/rubocop:
-          <<: *ruby_3_1_defaults
-          name: ruby-3_1-rubocop
-      - ruby/rspec-unit:
-          <<: *ruby_3_1_defaults
-          name: ruby-3_1-rspec_unit
-          db: false
-          code-climate: false
   ruby_3_2:
     jobs:
       - ruby/bundle-audit:
@@ -70,7 +39,6 @@ workflows:
           <<: *ruby_3_2_defaults
           name: ruby-3_2-rspec_unit
           db: false
-          code-climate: false
   ruby_3_3:
     jobs:
       - ruby/bundle-audit:
@@ -83,4 +51,15 @@ workflows:
           <<: *ruby_3_3_defaults
           name: ruby-3_3-rspec_unit
           db: false
-          code-climate: false
+  ruby_3_4:
+    jobs:
+      - ruby/bundle-audit:
+          <<: *ruby_3_4_defaults
+          name: ruby-3_4-bundle_audit
+      - ruby/rubocop:
+          <<: *ruby_3_4_defaults
+          name: ruby-3_4-rubocop
+      - ruby/rspec-unit:
+          <<: *ruby_3_4_defaults
+          name: ruby-3_4-rspec_unit
+          db: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
   NewCops: enable
   Exclude:
     - spec/**/*
@@ -10,8 +10,10 @@ AllCops:
     - log/**/*
     - Rakefile
     - bc-lightstep-ruby.gemspec
-require:
+plugins:
   - rubocop-performance
+  - rubocop-rake
+  - rubocop-rspec
 
 Lint/AmbiguousOperator:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the bc-lightstep-ruby gem.
 
 ### Pending Release
 
+* Add support for Ruby 3.4
+* Drop support for Ruby 3.0, 3.1
+
 ### 2.7.0
 
 * Do not instrument redis 5.x in this library for compatibility reasons; instead encourage moving away from

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem 'rspec', '>= 3.8'
 gem 'rspec_junit_formatter', '~> 0.4'
 gem 'rubocop', '>= 1.0'
 gem 'rubocop-performance', '>= 1.5'
+gem 'rubocop-rake'
+gem 'rubocop-rspec'
 gem 'simplecov', '~> 0.15'
 
 gemspec

--- a/bc-lightstep-ruby.gemspec
+++ b/bc-lightstep-ruby.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'bc-lightstep-ruby.gemspec']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.0'
+  spec.required_ruby_version = '>= 3.2'
   spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.add_runtime_dependency 'activesupport', '>= 4'

--- a/lib/bigcommerce/lightstep/interceptors/env.rb
+++ b/lib/bigcommerce/lightstep/interceptors/env.rb
@@ -105,12 +105,12 @@ module Bigcommerce
         ##
         # Handle access to values in a thread-safe manner
         #
-        def value_mutex(&block)
+        def value_mutex(&)
           @value_mutex ||= begin
             require 'monitor'
             Monitor.new
           end
-          @value_mutex.synchronize(&block)
+          @value_mutex.synchronize(&)
         end
       end
     end

--- a/lib/bigcommerce/lightstep/interceptors/registry.rb
+++ b/lib/bigcommerce/lightstep/interceptors/registry.rb
@@ -91,12 +91,12 @@ module Bigcommerce
         ##
         # Handle mutations to the registry in a thread-safe manner
         #
-        def registry_mutex(&block)
+        def registry_mutex(&)
           @registry_mutex ||= begin
             require 'monitor'
             Monitor.new
           end
-          @registry_mutex.synchronize(&block)
+          @registry_mutex.synchronize(&)
         end
       end
     end


### PR DESCRIPTION
## What/Why?

* Add support for Ruby 3.4
* Drop support for Ruby 3.0, 3.1

## Rollout/Rollback

Revert.

## Testing

Unit suite should pass.